### PR TITLE
Parse .babelrc as JSON5

### DIFF
--- a/load-config.js
+++ b/load-config.js
@@ -6,7 +6,8 @@ const readJson = file => {
     const content = fs.readFileSync(file, {encoding: 'utf8'});
     return JSON.parse(content);
   } catch (_e) {
-    return false;
+    console.error('babel6-brunch: Error loading JSON file "' + file + '"');
+    throw _e;
   }
 };
 

--- a/load-config.js
+++ b/load-config.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const sysPath = require('path');
+const JSON5 = require('json5');
 
 const readJson = file => {
   try {
@@ -11,11 +12,23 @@ const readJson = file => {
   }
 };
 
+const readJson5 = file => {
+  try {
+    const content = fs.readFileSync(file, {encoding: 'utf8'});
+    return JSON5.parse(content);
+  } catch (_e) {
+    console.error('babel6-brunch: Error loading JSON5 file "' + file + '"');
+    throw _e;
+  }
+};
+
 const getDefaultRc = root => {
-  const rc = readJson(sysPath.resolve(root, '.babelrc'));
+  // `.babelrc` is JSON5
+  const rc = readJson5(sysPath.resolve(root, '.babelrc'));
   if (rc) {
     return rc;
   }
+  // `package.json` is standard JSON
   const pkg = readJson(sysPath.resolve(root, 'package.json'));
   if (pkg && pkg.babel) {
     return pkg.babel;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "babel-core": "^6.0.0",
     "anymatch": "^1.0.0",
-    "babel-preset-es2015": "^6.0.0"
+    "babel-preset-es2015": "^6.0.0",
+    "json5": "^0.5.1"
   },
   "devDependencies": {
     "babel-plugin-transform-node-env-inline": "^6.1.18",


### PR DESCRIPTION
`.babelrc` is JSON5 not plain JSON -- this pull requests add the `json5` package so that it can be parsed as JSON5.

This pull request also bubbles parse errors from JSON or JSON5 to the end user, instead of ignoring them so that any syntax errors present in `.babelrc` can be fixed.

Reference: https://babeljs.io/docs/usage/babelrc/